### PR TITLE
B fix select storybook 03082021

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,6 +67,6 @@
     "plop": "^2.7.4",
     "prettier": "^2.2.1",
     "react-is": "^17.0.1",
-    "typescript": "^4.2.2"
+    "typescript": "4.1.5"
   }
 }

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "add": "^2.0.6",
     "next": "^10.0.7",
     "next-pwa": "^5.0.5",
+    "polished": "^4.1.1",
     "react": "^17.0.1",
     "react-dom": "^17.0.1",
     "styled-components": "5.2.1",

--- a/src/components/Ribbon/__snapshots__/test.tsx.snap
+++ b/src/components/Ribbon/__snapshots__/test.tsx.snap
@@ -1,0 +1,52 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<Ribbon /> should render the text correctly 1`] = `
+.c0 {
+  position: absolute;
+  top: 1.6rem;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  font-weight: 600;
+  color: #FAFAFA;
+  background-color: #F231A5;
+  font-size: 1.4rem;
+  padding: 0 2.4rem;
+  height: 3.6rem;
+  right: -2rem;
+}
+
+.c0::before {
+  content: '';
+  position: absolute;
+  right: 0;
+  border-style: solid;
+  border-left-width: 0rem;
+  border-right-color: transparent;
+  border-bottom-color: transparent;
+  border-bottom-width: 1rem;
+}
+
+.c0::before {
+  border-left-color: #b20b6f;
+  border-top-color: #b20b6f;
+}
+
+.c0::before {
+  top: 3.6rem;
+  border-top-width: 1rem;
+  border-right-width: 2rem;
+}
+
+<div
+  class="c0"
+  color="primary"
+>
+  Best Seller
+</div>
+`;

--- a/src/components/Ribbon/styles.ts
+++ b/src/components/Ribbon/styles.ts
@@ -1,26 +1,65 @@
 import styled, { css, DefaultTheme } from 'styled-components'
+import { darken } from 'polished'
 
 import { RibbonProps, RibbonColors } from '.'
 
 const wrapperModifiers = {
   color: (theme: DefaultTheme, color: RibbonColors) => css`
     background-color: ${theme.colors[color]};
+
+    &::before {
+      border-left-color: ${darken(0.2, theme.colors[color])};
+      border-top-color: ${darken(0.2, theme.colors[color])};
+    }
   `,
 
   normal: (theme: DefaultTheme) => css`
     font-size: ${theme.font.sizes.small};
+    padding: 0 ${theme.spacings.small};
     height: 3.6rem;
+    right: -2rem;
+
+    &::before {
+      top: 3.6rem;
+      border-top-width: 1rem;
+      border-right-width: 2rem;
+    }
   `,
 
   small: (theme: DefaultTheme) => css`
     font-size: ${theme.font.sizes.xsmall};
+    padding: 0 ${theme.spacings.xsmall};
     height: 2.6rem;
+
+    &::before {
+      top: 2.6rem;
+      border-top-width: 0.7rem;
+      border-right-width: 1.5rem;
+    }
   `,
 }
 
-export const Wrapper = styled.div<Omit<RibbonProps, 'children'>>`
+export const Wrapper = styled.div<RibbonProps>`
   ${({ theme, color, size }) => css`
-    ${!!size && wrapperModifiers[size](theme)}
+    position: absolute;
+    top: ${theme.spacings.xsmall};
+    display: flex;
+    align-items: center;
+    font-weight: ${theme.font.bold};
+    color: ${theme.colors.white};
+
+    &::before {
+      content: '';
+      position: absolute;
+      right: 0;
+      border-style: solid;
+      border-left-width: 0rem;
+      border-right-color: transparent;
+      border-bottom-color: transparent;
+      border-bottom-width: 1rem;
+    }
+
     ${!!color && wrapperModifiers.color(theme, color)}
+    ${!!size && wrapperModifiers[size](theme)}
   `}
 `

--- a/src/components/Ribbon/test.tsx
+++ b/src/components/Ribbon/test.tsx
@@ -5,9 +5,10 @@ import Ribbon from '.'
 
 describe('<Ribbon />', () => {
   it('should render the text correctly', () => {
-    renderWithTheme(<Ribbon>Best Seller</Ribbon>)
+    const { container } = renderWithTheme(<Ribbon>Best Seller</Ribbon>)
 
     expect(screen.getByText(/Best Seller/i)).toBeInTheDocument()
+    expect(container.firstChild).toMatchSnapshot()
   })
 
   it('should render with the primary color', () => {

--- a/src/types/jest-styled-components.d.ts
+++ b/src/types/jest-styled-components.d.ts
@@ -20,7 +20,7 @@ declare global {
       supports?: string
     }
 
-    interface Matchers<R, T> {
+    interface Matchers<R> {
       toHaveStyleRule(property: string, value?: Value, options?: Options): R
     }
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -10393,6 +10393,13 @@ polished@^3.4.4:
   dependencies:
     "@babel/runtime" "^7.9.2"
 
+polished@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/polished/-/polished-4.1.1.tgz#40442cc973348e466f2918cdf647531bb6c29bfb"
+  integrity sha512-4MZTrfPMPRLD7ac8b+2JZxei58zw6N1hFkdBDERif5Tlj19y3vPoPusrLG+mJIlPTGnUlKw3+yWz0BazvMx1vg==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+
 posix-character-classes@^0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/posix-character-classes/-/posix-character-classes-0.1.1.tgz#01eac0fe3b5af71a2a6c02feabb8c1fef7e00eab"

--- a/yarn.lock
+++ b/yarn.lock
@@ -12856,10 +12856,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@^4.2.2:
-  version "4.2.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.2.2.tgz#1450f020618f872db0ea17317d16d8da8ddb8c4c"
-  integrity sha512-tbb+NVrLfnsJy3M59lsDgrzWIflR4d4TIUjz+heUnHZwdF7YsrMTKoRERiIvI2lvBG95dfpLxB21WZhys1bgaQ==
+typescript@4.1.5:
+  version "4.1.5"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.1.5.tgz#123a3b214aaff3be32926f0d8f1f6e704eb89a72"
+  integrity sha512-6OSu9PTIzmn9TCDiovULTnET6BgXtDYL4Gg4szY+cGsc3JP1dQL8qvE8kShTRx1NIw4Q9IBHlwODjkjWEtMUyA==
 
 uglify-js@^3.1.4:
   version "3.11.0"


### PR DESCRIPTION
Selects no Stoybook estavam sendo exibidos como input text. Pesquisando, cheguei nessa issue (https://github.com/storybookjs/storybook/issues/12641), que a resolução é baseada no downgrade do Typescript para a versão 4.1.5, assim, retorna para um radio button (e possívelmente um select, dependendo da quantidade de valores).